### PR TITLE
Add GitHub links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,3 +16,5 @@ Imports:
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr
+URL: https://github.com/vpnagraj/rrefine
+BugReports: https://github.com/vpnagraj/rrefine/issues


### PR DESCRIPTION
Makes it easier to locate the development repo for this project from the package page on CRAN.